### PR TITLE
Fix checkbox and admonition

### DIFF
--- a/BOOSTNOTE_MARKDOWN_CHEAT_SHEET.md
+++ b/BOOSTNOTE_MARKDOWN_CHEAT_SHEET.md
@@ -75,8 +75,8 @@ H~2~0
 `Jump to line`: [Go to line 200](:line:200)
 
 ### Check box
-- [x] Task 1
-- [ ] Task 2
+`- [x]` Task 1 <br/>
+`- [ ]` Task 2
 
 ### Quotation
 > Quotation
@@ -212,27 +212,27 @@ Horizontal lines have various ways of writing.
 
 ### Admonition
 
-!!! note Note
+!!! note <br/>
+Lorem ipsum <br/>
+!!!
+
+!!! hint <br/> <br/>
+Lorem ipsum <br/>
+!!!
+
+!!! caution <br/>
+Lorem ipsum <br/>
+!!!
+
+!!! error <br/>
 Lorem ipsum
 !!!
 
-!!! hint Hint
+!!! attention <br/>
 Lorem ipsum
 !!!
 
-!!! caution Caution
-Lorem ipsum
-!!!
-
-!!! error Error
-Lorem ipsum
-!!!
-
-!!! attention Attention
-Lorem ipsum
-!!!
-
-!!! danger Danger
+!!! danger <br/>
 Lorem ipsum
 !!!
 


### PR DESCRIPTION
- Check box: it was rendered by Github to visual checkbox, so it doesn't say how to really declare checkbox in Boosnote.
- Admonition: it should be !!!type [line break] message [line break] !!!, so the correct text in this readme page is !!!type <br/> message <br/> !!!.  Otherwise (witouth <br/>) the admonition won't be closed, i.e., everything you write after the Admonition block will be inside the block.
EDIT: sorry; just noted that I didn't put all the <br/> needed for the 2nd point (error, attention and danger), but you get the idea; I also mistakenly put double <br/> near 'hint'. Whoever is going to pick this up, please fix those latter as well.