### PR TITLE
Fixed typo in emoticons in Table Of Contents

### DIFF
--- a/BOOSTNOTE_MARKDOWN_CHEAT_SHEET.md
+++ b/BOOSTNOTE_MARKDOWN_CHEAT_SHEET.md
@@ -28,7 +28,7 @@ It tries to give a short summary of all formatting options which are available i
   * [Quotation](#Quotation)
   * [Footnotes](#Footnotes)
   * [Html](#Html)
-  * [Emotiocons](#Emotiocons)
+  * [Emoticons](#Emoticons)
   * [Arrows](#Arrows)
   * [Keystrokes](#Keystrokes)
   * [Source Code](#Source-Code)


### PR DESCRIPTION
It wouldn't jump because it referenced an incorrect header.